### PR TITLE
Fix config path and update item id after wicker basket extraction

### DIFF
--- a/fabric/src/main/java/com/github/leopoko/solclassic/fabric/config/SolClassicConfigLoaderFabric.java
+++ b/fabric/src/main/java/com/github/leopoko/solclassic/fabric/config/SolClassicConfigLoaderFabric.java
@@ -46,7 +46,7 @@ public class SolClassicConfigLoaderFabric {
     public static void loadConfig(MinecraftServer server) {
         try {
             // サーバーのルートディレクトリから config フォルダを取得
-            Path configDir = server.getWorldPath(LevelResource.ROOT).resolve("severconfig");
+            Path configDir = server.getWorldPath(LevelResource.ROOT).resolve("serverconfig");
             if (!Files.exists(configDir)) {
                 Files.createDirectories(configDir);
             }

--- a/fabric/src/main/java/com/github/leopoko/solclassic/fabric/mixin/PlayerMixinFabric.java
+++ b/fabric/src/main/java/com/github/leopoko/solclassic/fabric/mixin/PlayerMixinFabric.java
@@ -35,6 +35,8 @@ public class PlayerMixinFabric {
         if (itemId.equals("solclassic:wicker_basket")) {
             WickerBasketItem wickerBasketItem = (WickerBasketItem) itemStack.getItem();
             itemStack = wickerBasketItem.getMostNutritiousFood(itemStack, player);
+            // Update itemId to the actual food item after extraction
+            itemId = BuiltInRegistries.ITEM.getKey(itemStack.getItem()).toString();
         }
 
         for (String itemID_ : SolclassicConfigData.foodBlacklist) {

--- a/forge/src/main/java/com/github/leopoko/solclassic/forge/mixin/PlayerMixinForge.java
+++ b/forge/src/main/java/com/github/leopoko/solclassic/forge/mixin/PlayerMixinForge.java
@@ -38,6 +38,8 @@ public class PlayerMixinForge {
         if (itemId.equals("solclassic:wicker_basket")){
             WickerBasketItem wickerBasketItem = (WickerBasketItem) entity.getItem();
             entity = wickerBasketItem.getMostNutritiousFood(entity, player);
+            // Update itemId after retrieving the actual food item
+            itemId = BuiltInRegistries.ITEM.getKey(entity.getItem()).toString();
         }
 
         for (String itemID_ : SolClassicConfigForge.CONFIG.foodBlacklist.get()) {


### PR DESCRIPTION
## Summary
- fix wrong folder name for Fabric config loader
- recompute item id after retrieving food item from wicker basket in both mixins

## Testing
- `./gradlew tasks --all` *(fails: plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411de1b6908326a7fb073378079df7