### PR TITLE
Fix default blacklist item

### DIFF
--- a/common/src/main/java/com/github/leopoko/solclassic/config/SolclassicConfigData.java
+++ b/common/src/main/java/com/github/leopoko/solclassic/config/SolclassicConfigData.java
@@ -8,6 +8,7 @@ public class SolclassicConfigData {
     public static int maxShortFoodHistorySize = 5;
     public static float longFoodDecayModifiers = 0.01F;
     public static List<Float> shortFoodDecayModifiers = Arrays.asList(1.0F, 0.9F, 0.75F, 0.5F, 0.05F);
-    public static List<String> foodBlacklist = Arrays.asList("minecraft:kelp");
+    // Items that will not be affected by food history tracking
+    public static List<String> foodBlacklist = Arrays.asList("minecraft:dried_kelp");
     public static boolean enableWickerBasket = true;
 }


### PR DESCRIPTION
## Summary
- use `minecraft:dried_kelp` in the default blacklist

## Testing
- `./gradlew build` *(fails: plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411f209ba88326b5ff9a0e97666070