### PR TITLE
ツールチップ表示制御のconfig設定を追加 (v2.08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [2.08+1.21.1] - 2026-03-11
+
+### Added
+- Added `enableTooltip` config option (default: true): controls whether the food decay tooltip ("Hunger recovery reduced by X%") is shown on food items.
+- Added `enableItemDescription` config option (default: true): controls whether description tooltips are shown on mod items (Wicker Basket, Food History Book).
+
+---
+
+## [2.08+1.21.1] - 2026-03-11 (日本語)
+
+### 追加
+- `enableTooltip` 設定項目を追加（デフォルト: true）: 食べ物アイテムに表示される減衰率ツールチップ（「満腹度回復が X% 減少しています」）の表示/非表示を切り替える。
+- `enableItemDescription` 設定項目を追加（デフォルト: true）: MODアイテム（WickerBasket、食事記録の本）の説明文ツールチップの表示/非表示を切り替える。
+
+---
+
 ## [2.07+1.21.1] - 2026-03-10
 
 ### Fixed

--- a/common/src/main/java/com/github/leopoko/solclassic/config/SolclassicConfigData.java
+++ b/common/src/main/java/com/github/leopoko/solclassic/config/SolclassicConfigData.java
@@ -13,4 +13,8 @@ public class SolclassicConfigData {
     public static boolean enableWickerBasket = true;
     // 満腹度回復率が0%の食べ物に最低限1の回復を保証するかどうか
     public static boolean guaranteeMinimumNutrition = false;
+    // 食べ物アイテムの減衰率ツールチップの表示/非表示
+    public static boolean enableTooltip = true;
+    // MODアイテム（WickerBasket、食事記録の本）の説明文ツールチップの表示/非表示
+    public static boolean enableItemDescription = true;
 }

--- a/common/src/main/java/com/github/leopoko/solclassic/config/SolclassicGlobalDefaults.java
+++ b/common/src/main/java/com/github/leopoko/solclassic/config/SolclassicGlobalDefaults.java
@@ -28,6 +28,8 @@ public class SolclassicGlobalDefaults {
     public List<String> foodBlacklist = Arrays.asList("minecraft:dried_kelp");
     public boolean enableWickerBasket = true;
     public boolean guaranteeMinimumNutrition = false;
+    public boolean enableTooltip = true;
+    public boolean enableItemDescription = true;
 
     /**
      * config ディレクトリから solclassic-defaults.toml を読み込む。
@@ -95,6 +97,12 @@ public class SolclassicGlobalDefaults {
                         break;
                     case "guaranteeMinimumNutrition":
                         this.guaranteeMinimumNutrition = Boolean.parseBoolean(value);
+                        break;
+                    case "enableTooltip":
+                        this.enableTooltip = Boolean.parseBoolean(value);
+                        break;
+                    case "enableItemDescription":
+                        this.enableItemDescription = Boolean.parseBoolean(value);
                         break;
                     default:
                         // 未知のキーは無視
@@ -170,7 +178,11 @@ public class SolclassicGlobalDefaults {
         sb.append("#Enable Wicker Basket\n");
         sb.append("enableWickerBasket = ").append(defaults.enableWickerBasket).append("\n");
         sb.append("#Guarantee minimum 1 nutrition even when decay reduces it to 0. When false, fully decayed food gives no nutrition.\n");
-        sb.append("guaranteeMinimumNutrition = ").append(defaults.guaranteeMinimumNutrition);
+        sb.append("guaranteeMinimumNutrition = ").append(defaults.guaranteeMinimumNutrition).append("\n");
+        sb.append("#Enable food decay tooltip on food items\n");
+        sb.append("enableTooltip = ").append(defaults.enableTooltip).append("\n");
+        sb.append("#Enable description tooltip on mod items (Wicker Basket, Food History Book)\n");
+        sb.append("enableItemDescription = ").append(defaults.enableItemDescription);
         return sb.toString();
     }
 
@@ -192,6 +204,8 @@ public class SolclassicGlobalDefaults {
         defaults.foodBlacklist = new ArrayList<>(SolclassicConfigData.foodBlacklist);
         defaults.enableWickerBasket = SolclassicConfigData.enableWickerBasket;
         defaults.guaranteeMinimumNutrition = SolclassicConfigData.guaranteeMinimumNutrition;
+        defaults.enableTooltip = SolclassicConfigData.enableTooltip;
+        defaults.enableItemDescription = SolclassicConfigData.enableItemDescription;
 
         StringBuilder sb = new StringBuilder();
         sb.append("# Spice of Life: Classic Edition - Global Default Settings\n");

--- a/common/src/main/java/com/github/leopoko/solclassic/item/FoodHistoryBookItem.java
+++ b/common/src/main/java/com/github/leopoko/solclassic/item/FoodHistoryBookItem.java
@@ -1,5 +1,6 @@
 package com.github.leopoko.solclassic.item;
 
+import com.github.leopoko.solclassic.config.SolclassicConfigData;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
@@ -36,6 +37,7 @@ public class FoodHistoryBookItem extends Item {
 
     @Override
     public void appendHoverText(@NotNull ItemStack stack, @NotNull Item.TooltipContext context, @NotNull List<Component> tooltip, @NotNull TooltipFlag flag) {
+        if (!SolclassicConfigData.enableItemDescription) return;
         tooltip.add(Component.translatable("tooltip.food_history_book.description"));
     }
 }

--- a/common/src/main/java/com/github/leopoko/solclassic/item/WickerBasketItem.java
+++ b/common/src/main/java/com/github/leopoko/solclassic/item/WickerBasketItem.java
@@ -94,6 +94,7 @@ public class WickerBasketItem extends Item {
 
     @Override
     public void appendHoverText(@NotNull ItemStack stack, @NotNull Item.TooltipContext context, List<Component> tooltip, @NotNull TooltipFlag flag) {
+        if (!SolclassicConfigData.enableItemDescription) return;
         tooltip.add(Component.translatable("tooltip.wicker_basket.description1"));
         tooltip.add(Component.translatable("tooltip.wicker_basket.description2"));
     }

--- a/common/src/main/java/com/github/leopoko/solclassic/utils/ClientTooltipHandler.java
+++ b/common/src/main/java/com/github/leopoko/solclassic/utils/ClientTooltipHandler.java
@@ -1,6 +1,7 @@
 package com.github.leopoko.solclassic.utils;
 
 import com.github.leopoko.solclassic.client.FoodHistoryBookScreen;
+import com.github.leopoko.solclassic.config.SolclassicConfigData;
 import com.github.leopoko.solclassic.item.FoodHistoryBookItem;
 import com.github.leopoko.solclassic.item.WickerBasketItem;
 import com.github.leopoko.solclassic.network.FoodHistoryHolder;
@@ -24,6 +25,7 @@ public class ClientTooltipHandler {
         FoodHistoryBookItem.screenOpener = FoodHistoryBookScreen::open;
 
         ClientTooltipEvent.ITEM.register((ItemStack stack, List<Component> tooltips, Item.TooltipContext context, TooltipFlag flag) -> {
+            if (!SolclassicConfigData.enableTooltip) return;
             if (stack.getItem() instanceof WickerBasketItem) {
                 // WickerBasket: 選択された食べ物の情報を表示
                 Player player = Minecraft.getInstance().player;

--- a/fabric/src/main/java/com/github/leopoko/solclassic/fabric/config/SolClassicConfigLoaderFabric.java
+++ b/fabric/src/main/java/com/github/leopoko/solclassic/fabric/config/SolClassicConfigLoaderFabric.java
@@ -63,8 +63,10 @@ public class SolClassicConfigLoaderFabric {
             Double longFoodDecayModifiersVal = settings.getDouble("longFoodDecayModifiers");
             Boolean enableWickerBasket = settings.getBoolean("enableWickerBasket");
             Boolean guaranteeMinimumNutrition = settings.getBoolean("guaranteeMinimumNutrition");
+            Boolean enableTooltip = settings.getBoolean("enableTooltip");
+            Boolean enableItemDescription = settings.getBoolean("enableItemDescription");
 
-            if (maxFoodHistoryVal == null || maxShortFoodHistoryVal == null || longFoodDecayModifiersVal == null || enableWickerBasket == null || guaranteeMinimumNutrition == null) {
+            if (maxFoodHistoryVal == null || maxShortFoodHistoryVal == null || longFoodDecayModifiersVal == null || enableWickerBasket == null || guaranteeMinimumNutrition == null || enableTooltip == null || enableItemDescription == null) {
                 server.sendSystemMessage(Component.literal("Invalid config keys detected. Recreating default config."));
                 recreateDefaultConfig(server, configFile);
                 result = Toml.parse(configFile);
@@ -74,6 +76,8 @@ public class SolClassicConfigLoaderFabric {
                 longFoodDecayModifiersVal = settings.getDouble("longFoodDecayModifiers");
                 enableWickerBasket = settings.getBoolean("enableWickerBasket");
                 guaranteeMinimumNutrition = settings.getBoolean("guaranteeMinimumNutrition");
+                enableTooltip = settings.getBoolean("enableTooltip");
+                enableItemDescription = settings.getBoolean("enableItemDescription");
             }
 
             // shortFoodDecayModifiers は List<Double> として取得（値は Number 型なので変換する）
@@ -97,6 +101,8 @@ public class SolClassicConfigLoaderFabric {
             SolclassicConfigData.longFoodDecayModifiers = longFoodDecayModifiersVal.floatValue();
             SolclassicConfigData.enableWickerBasket = enableWickerBasket;
             SolclassicConfigData.guaranteeMinimumNutrition = guaranteeMinimumNutrition;
+            SolclassicConfigData.enableTooltip = enableTooltip;
+            SolclassicConfigData.enableItemDescription = enableItemDescription;
 
         } catch (IOException e) {
             e.printStackTrace();

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.parallel=true
 # Minecraft 1.21.1 requires Java 21+
 org.gradle.java.home=C:\\Program Files\\Eclipse Adoptium\\jdk-22.0.2.9-hotspot
 # Mod properties
-mod_version=2.07+1.21.1
+mod_version=2.08+1.21.1
 maven_group=com.github.leopoko
 archives_name=spiceoflife_classic
 enabled_platforms=fabric,neoforge

--- a/neoforge/src/main/java/com/github/leopoko/solclassic/neoforge/config/SolClassicConfigInitNeoForge.java
+++ b/neoforge/src/main/java/com/github/leopoko/solclassic/neoforge/config/SolClassicConfigInitNeoForge.java
@@ -22,5 +22,7 @@ public class SolClassicConfigInitNeoForge {
         SolclassicConfigData.foodBlacklist = new ArrayList<>(SolClassicConfigNeoForge.CONFIG.foodBlacklist.get());
         SolclassicConfigData.enableWickerBasket = SolClassicConfigNeoForge.CONFIG.enableWickerBasket.get();
         SolclassicConfigData.guaranteeMinimumNutrition = SolClassicConfigNeoForge.CONFIG.guaranteeMinimumNutrition.get();
+        SolclassicConfigData.enableTooltip = SolClassicConfigNeoForge.CONFIG.enableTooltip.get();
+        SolclassicConfigData.enableItemDescription = SolClassicConfigNeoForge.CONFIG.enableItemDescription.get();
     }
 }

--- a/neoforge/src/main/java/com/github/leopoko/solclassic/neoforge/config/SolClassicConfigNeoForge.java
+++ b/neoforge/src/main/java/com/github/leopoko/solclassic/neoforge/config/SolClassicConfigNeoForge.java
@@ -25,6 +25,8 @@ public class SolClassicConfigNeoForge {
         public final ModConfigSpec.ConfigValue<List<? extends String>> foodBlacklist;
         public final ModConfigSpec.BooleanValue enableWickerBasket;
         public final ModConfigSpec.BooleanValue guaranteeMinimumNutrition;
+        public final ModConfigSpec.BooleanValue enableTooltip;
+        public final ModConfigSpec.BooleanValue enableItemDescription;
 
         public ServerConfig(ModConfigSpec.Builder builder) {
             // NeoForge 1.21.1 ではSERVERコンフィグは config/ ディレクトリにグローバルに保存されます。
@@ -68,6 +70,14 @@ public class SolClassicConfigNeoForge {
             guaranteeMinimumNutrition = builder
                     .comment("Guarantee minimum 1 nutrition even when decay reduces it to 0. When false, fully decayed food gives no nutrition.")
                     .define("guaranteeMinimumNutrition", false);
+
+            enableTooltip = builder
+                    .comment("Enable food decay tooltip on food items")
+                    .define("enableTooltip", true);
+
+            enableItemDescription = builder
+                    .comment("Enable description tooltip on mod items (Wicker Basket, Food History Book)")
+                    .define("enableItemDescription", true);
 
             builder.pop();
         }


### PR DESCRIPTION
## Summary
- `enableTooltip` 設定を追加: 食べ物アイテムの減衰率ツールチップ（「満腹度回復が X% 減少しています」）の表示/非表示を切り替え（デフォルト: true）
- `enableItemDescription` 設定を追加: MODアイテム（WickerBasket、食事記録の本）の説明文ツールチップの表示/非表示を切り替え（デフォルト: true）
- 両設定ともサーバーconfigとして定義（NeoForgeは自動同期、Fabricはサーバー起動時読み込み）

## 変更ファイル
| レイヤー | ファイル | 変更内容 |
|----------|----------|----------|
| 共通 | `SolclassicConfigData` | `enableTooltip`, `enableItemDescription` フィールド追加 |
| 共通 | `ClientTooltipHandler` | `enableTooltip` チェック追加 |
| 共通 | `WickerBasketItem` | `enableItemDescription` チェック追加 |
| 共通 | `FoodHistoryBookItem` | `enableItemDescription` チェック追加 + import |
| 共通 | `SolclassicGlobalDefaults` | 両設定のフィールド・パーサー・TOML生成・書き出し追加 |
| Fabric | `SolClassicConfigLoaderFabric` | 両設定のTOML読み込み + nullチェック条件追加 |
| NeoForge | `SolClassicConfigNeoForge` | 両設定の `ModConfigSpec.BooleanValue` 定義追加 |
| NeoForge | `SolClassicConfigInitNeoForge` | 両設定の `ConfigData` への反映追加 |

## Test plan
- [ ] Fabric/NeoForgeでビルドが通ることを確認
- [ ] `enableTooltip = false` 時に食べ物の減衰率ツールチップが非表示になることを確認
- [ ] `enableItemDescription = false` 時にWickerBasketと食事記録の本の説明文が非表示になることを確認
- [ ] デフォルト設定（両方true）で従来通りツールチップが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)