### PR TITLE
Caching optimisations

### DIFF
--- a/common/src/main/java/com/github/leopoko/solclassic/client/FoodHistoryBookScreen.java
+++ b/common/src/main/java/com/github/leopoko/solclassic/client/FoodHistoryBookScreen.java
@@ -2,6 +2,7 @@ package com.github.leopoko.solclassic.client;
 
 import com.github.leopoko.solclassic.network.FoodHistoryHolder;
 import com.github.leopoko.solclassic.utils.FoodCalculator;
+import com.github.leopoko.solclassic.utils.FoodHistory;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
@@ -63,7 +64,7 @@ public class FoodHistoryBookScreen extends Screen {
      * 最近食べた順にソートし、各食べ物の回数と減衰率を計算する。
      */
     private List<FoodEntry> buildFoodEntries() {
-        LinkedList<ItemStack> history = FoodHistoryHolder.INSTANCE.getClientFoodHistory(player);
+        LinkedList<ItemStack> history = FoodHistoryHolder.INSTANCE.getClientFoodHistory(player).consumedItems;
         if (history == null || history.isEmpty()) {
             return Collections.emptyList();
         }

--- a/common/src/main/java/com/github/leopoko/solclassic/network/ClientPacketHandler.java
+++ b/common/src/main/java/com/github/leopoko/solclassic/network/ClientPacketHandler.java
@@ -1,5 +1,6 @@
 package com.github.leopoko.solclassic.network;
 
+import com.github.leopoko.solclassic.utils.FoodHistory;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -8,7 +9,7 @@ import java.util.LinkedList;
 
 public class ClientPacketHandler {
     // クライアント側で受信した食事履歴をプレイヤーに反映する
-    public static void handleFoodHistoryPacket(LinkedList<ItemStack> foodHistory) {
+    public static void handleFoodHistoryPacket(FoodHistory foodHistory) {
         Player player = Minecraft.getInstance().player;
         if (player != null) {
             FoodHistoryHolder.INSTANCE.setFoodHistory(player, foodHistory);

--- a/common/src/main/java/com/github/leopoko/solclassic/network/FoodHistorySync.java
+++ b/common/src/main/java/com/github/leopoko/solclassic/network/FoodHistorySync.java
@@ -1,14 +1,14 @@
 package com.github.leopoko.solclassic.network;
 
+import com.github.leopoko.solclassic.utils.FoodHistory;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 
-import java.util.LinkedList;
 
 public class FoodHistorySync {
     // サーバー側で、FoodEventHandler 経由で取得した食事履歴をクライアントに送信する
     public static void syncFoodHistory(ServerPlayer player) {
-        LinkedList<ItemStack> foodHistory = FoodHistoryHolder.INSTANCE.getFoodHistory(player);
+        FoodHistory foodHistory = FoodHistoryHolder.INSTANCE.getFoodHistory(player);
         ModNetworking.sendToPlayer(player, new SyncFoodHistoryPacket(foodHistory));
     }
 }

--- a/common/src/main/java/com/github/leopoko/solclassic/network/IFoodEventHandler.java
+++ b/common/src/main/java/com/github/leopoko/solclassic/network/IFoodEventHandler.java
@@ -1,5 +1,6 @@
 package com.github.leopoko.solclassic.network;
 
+import com.github.leopoko.solclassic.utils.FoodHistory;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
@@ -17,7 +18,7 @@ public interface IFoodEventHandler {
      * @param player サーバー側のプレイヤー
      * @return 食事履歴の LinkedList (存在しない場合は新規作成)
      */
-    public LinkedList<ItemStack> getFoodHistory(ServerPlayer player);
+    public FoodHistory getFoodHistory(ServerPlayer player);
 
     /**
      * サーバー側で、指定されたプレイヤーの食事履歴に新しいアイテムを追加します。
@@ -35,7 +36,7 @@ public interface IFoodEventHandler {
      * @param player      クライアント側のプレイヤー
      * @param foodHistory サーバーから送信された食事履歴
      */
-    public void setFoodHistory(Player player, LinkedList<ItemStack> foodHistory);
+    public void setFoodHistory(Player player, FoodHistory foodHistory);
 
     /**
      * サーバー側で、指定されたプレイヤーの食事履歴をリセットします。
@@ -71,7 +72,7 @@ public interface IFoodEventHandler {
      * @param player 対象のプレイヤー（サーバー/クライアントどちらでも可）
      * @return 食事履歴の LinkedList（存在しない場合は空リスト）
      */
-    public LinkedList<ItemStack> getClientFoodHistory(Player player);
+    public FoodHistory getClientFoodHistory(Player player);
 
     /**
      * ItemStackから実効的な栄養値を取得します。

--- a/common/src/main/java/com/github/leopoko/solclassic/network/SyncFoodHistoryPacket.java
+++ b/common/src/main/java/com/github/leopoko/solclassic/network/SyncFoodHistoryPacket.java
@@ -1,5 +1,6 @@
 package com.github.leopoko.solclassic.network;
 
+import com.github.leopoko.solclassic.utils.FoodHistory;
 import dev.architectury.networking.NetworkManager;
 import dev.architectury.platform.Platform;
 import net.minecraft.client.Minecraft;
@@ -7,32 +8,31 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.vehicle.Minecart;
 import net.minecraft.world.item.ItemStack;
 
-import java.util.LinkedList;
 import java.util.function.Supplier;
 
 public class SyncFoodHistoryPacket {
 
-    private final LinkedList<ItemStack> foodHistory;
+    private final FoodHistory foodHistory;
 
     // デコード用コンストラクタ
     public SyncFoodHistoryPacket(FriendlyByteBuf buf) {
         int size = buf.readInt();
-        LinkedList<ItemStack> list = new LinkedList<>();
+        FoodHistory history = new FoodHistory();
         for (int i = 0; i < size; i++) {
-            list.add(buf.readItem());
+            history.add(buf.readItem());
         }
-        this.foodHistory = list;
+        this.foodHistory = history;
     }
 
     // メッセージ作成用コンストラクタ
-    public SyncFoodHistoryPacket(LinkedList<ItemStack> foodHistory) {
+    public SyncFoodHistoryPacket(FoodHistory foodHistory) {
         this.foodHistory = foodHistory;
     }
 
     // エンコード：書き出し順に合わせてデータをバッファに書き込む
     public void encode(FriendlyByteBuf buf) {
-        buf.writeInt(this.foodHistory.size());
-        for (ItemStack stack : this.foodHistory) {
+        buf.writeInt(this.foodHistory.consumedItems.size());
+        for (ItemStack stack : this.foodHistory.consumedItems) {
             buf.writeItem(stack);
         }
     }
@@ -48,7 +48,7 @@ public class SyncFoodHistoryPacket {
     }
 
     // 必要に応じて getter も用意できます
-    public LinkedList<ItemStack> getFoodHistory() {
+    public FoodHistory getFoodHistory() {
         return foodHistory;
     }
 }

--- a/common/src/main/java/com/github/leopoko/solclassic/utils/FoodHistory.java
+++ b/common/src/main/java/com/github/leopoko/solclassic/utils/FoodHistory.java
@@ -1,0 +1,69 @@
+package com.github.leopoko.solclassic.utils;
+
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+public final class FoodHistory{
+	public final Map<Item, Integer> amountConsumed;
+	public final LinkedList<ItemStack> consumedItems;
+	public void clear(){
+		amountConsumed.clear();
+		consumedItems.clear();
+	}
+
+	public FoodHistory() {
+		amountConsumed = new HashMap<>();
+		consumedItems = new LinkedList<>();
+	}
+	public void add(ItemStack item, int maxHistory){
+		if(consumedItems.size() >= maxHistory) decrementConsumption(consumedItems.remove());
+		consumedItems.add(item);
+		incrementConsumption(item);
+	}
+	public void add(ItemStack item){
+		consumedItems.add(item);
+		incrementConsumption(item);
+	}
+	public int getAmountConsumed(ItemStack target){
+		return amountConsumed.getOrDefault(target.getItem(), 0);
+	}
+	private int incrementConsumption(ItemStack item){
+		int previousAmountConsumed = amountConsumed.getOrDefault(item.getItem(), 0);
+		amountConsumed.put(item.getItem(), previousAmountConsumed + 1);
+		return previousAmountConsumed + 1;
+	}
+	private int decrementConsumption(ItemStack item){
+		if(!amountConsumed.containsKey(item.getItem())){
+			Logger logger = Logger.getLogger("SOLClassic");
+			logger.severe("About to throw, Printing class that is throwing error");
+			logger.severe(toString());
+			throw new IllegalStateException("Attempted to remove non-existent item \""+BuiltInRegistries.ITEM.getKey(item.getItem()).toString()+"\" from food history");
+		}
+		int previousAmountConsumed = amountConsumed.get(item.getItem());
+		if(previousAmountConsumed <= 1){
+			amountConsumed.remove(item.getItem());
+			return 0;
+		}
+		else{
+			amountConsumed.put(item.getItem(), previousAmountConsumed - 1);
+			return previousAmountConsumed - 1;
+		}
+	}
+
+	@Override
+	public String toString() {
+		Iterator<String> mapEntries = amountConsumed.entrySet().stream().map(pair -> "\""+ BuiltInRegistries.ITEM.getKey(pair.getKey()) +"\": "+ pair.getValue()).iterator();
+		AtomicReference<String> mapValue = new AtomicReference<>("");
+		if(mapEntries.hasNext()) {
+			mapValue.set(mapEntries.next());
+			mapEntries.forEachRemaining(entry -> mapValue.set(mapValue + ", " + entry));
+		}
+		return "FoodHistory:{Map: {%b}, Queue: %b}".formatted(mapValue.get(), consumedItems);
+	}
+}

--- a/fabric/src/main/java/com/github/leopoko/solclassic/fabric/foodhistory/FoodHistoryComponentFabric.java
+++ b/fabric/src/main/java/com/github/leopoko/solclassic/fabric/foodhistory/FoodHistoryComponentFabric.java
@@ -1,6 +1,6 @@
 package com.github.leopoko.solclassic.fabric.foodhistory;
 
-import dev.onyxstudios.cca.api.v3.component.Component;
+import com.github.leopoko.solclassic.utils.FoodHistory;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
@@ -10,12 +10,12 @@ import java.util.LinkedList;
 
 public class FoodHistoryComponentFabric implements IFoodHistoryComponentFabric {
     private static final String FOOD_HISTORY_TAG = "FoodHistory";
-    private final LinkedList<ItemStack> history = new LinkedList<>();
+    private final FoodHistory history = new FoodHistory();
 
     /**
      * 現在の食事履歴を返します。
      */
-    public LinkedList<ItemStack> getHistory() {
+    public FoodHistory getHistory() {
         return history;
     }
 
@@ -26,12 +26,11 @@ public class FoodHistoryComponentFabric implements IFoodHistoryComponentFabric {
      *
      * @param newHistory 新しい食事履歴
      */
-    public void setFood(LinkedList<ItemStack> newHistory) {
-        LinkedList<ItemStack> copyHistory = new LinkedList<>(newHistory);
-        history.clear();
-        for (ItemStack stack : copyHistory) {
-            history.add(stack.copy());
-        }
+    public void setFood(FoodHistory newHistory) { // I don't think the history change needs to be detached
+        history.amountConsumed.clear();
+        history.amountConsumed.putAll(newHistory.amountConsumed);
+        history.consumedItems.clear();
+        history.consumedItems.addAll(newHistory.consumedItems);
     }
 
     /**
@@ -56,7 +55,7 @@ public class FoodHistoryComponentFabric implements IFoodHistoryComponentFabric {
     @Override
     public void writeToNbt(CompoundTag tag) {
         ListTag listTag = new ListTag();
-        for (ItemStack stack : history) {
+        for (ItemStack stack : history.consumedItems) {
             CompoundTag stackTag = new CompoundTag();
             stack.save(stackTag);
             listTag.add(stackTag);

--- a/fabric/src/main/java/com/github/leopoko/solclassic/fabric/foodhistory/IFoodHistoryComponentFabric.java
+++ b/fabric/src/main/java/com/github/leopoko/solclassic/fabric/foodhistory/IFoodHistoryComponentFabric.java
@@ -1,5 +1,6 @@
 package com.github.leopoko.solclassic.fabric.foodhistory;
 
+import com.github.leopoko.solclassic.utils.FoodHistory;
 import dev.onyxstudios.cca.api.v3.component.Component;
 import dev.onyxstudios.cca.api.v3.component.sync.AutoSyncedComponent;
 import net.minecraft.world.item.ItemStack;
@@ -10,11 +11,11 @@ public interface IFoodHistoryComponentFabric extends Component, AutoSyncedCompon
     /**
      * 現在の食事履歴（ItemStack の LinkedList）を返す
      */
-    LinkedList<ItemStack> getHistory();
+    FoodHistory getHistory();
 
     /**
      * 渡された食事履歴で内部データを上書きする
      * @param newHistory 外部から渡された食事履歴
      */
-    void setFood(LinkedList<ItemStack> newHistory);
+    void setFood(FoodHistory newHistory);
 }

--- a/fabric/src/main/java/com/github/leopoko/solclassic/fabric/network/FoodEventHandlerFabric.java
+++ b/fabric/src/main/java/com/github/leopoko/solclassic/fabric/network/FoodEventHandlerFabric.java
@@ -1,12 +1,7 @@
 package com.github.leopoko.solclassic.fabric.network;
 
-import com.github.leopoko.solclassic.fabric.foodhistory.IFoodHistoryComponentFabric;
 import com.github.leopoko.solclassic.network.IFoodEventHandler;
-import dev.onyxstudios.cca.api.v3.component.ComponentKey;
-import dev.onyxstudios.cca.api.v3.component.ComponentRegistry;
-import dev.onyxstudios.cca.api.v3.component.sync.AutoSyncedComponent;
-import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
+import com.github.leopoko.solclassic.utils.FoodHistory;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -15,9 +10,9 @@ import java.util.*;
 
 import static com.github.leopoko.solclassic.fabric.foodhistory.FoodHistoryComponentImplFabric.FOOD_HISTORY;
 
-public class FoodEventHandlerFabric  implements IFoodEventHandler {
+public class FoodEventHandlerFabric implements IFoodEventHandler {
     // プレイヤーごとの食事履歴を保存するマップ（キーはプレイヤーのUUID）
-    private static final Map<UUID, LinkedList<ItemStack>> foodHistories = new WeakHashMap<>();
+    private static final Map<UUID, FoodHistory> foodHistories = new WeakHashMap<>();
 
     //public static final ComponentKey<IFoodHistoryComponentFabric> FOOD_HISTORY = ComponentRegistry.getOrCreate(new ResourceLocation("solclassic", "food_history"), IFoodHistoryComponentFabric.class);
 
@@ -27,8 +22,8 @@ public class FoodEventHandlerFabric  implements IFoodEventHandler {
      * @param player サーバー側のプレイヤー
      * @return 食事履歴の LinkedList (存在しない場合は新規作成)
      */
-    public LinkedList<ItemStack> getFoodHistory(ServerPlayer player) {
-        LinkedList<ItemStack> history_ = FOOD_HISTORY.get(player).getHistory();
+    public FoodHistory getFoodHistory(ServerPlayer player) {
+        FoodHistory history_ = FOOD_HISTORY.get(player).getHistory();
         //return foodHistories.computeIfAbsent(player.getUUID(), uuid -> new LinkedList<>());
         return history_;
     }
@@ -41,12 +36,8 @@ public class FoodEventHandlerFabric  implements IFoodEventHandler {
      * @param foodStack 追加する食事アイテムの ItemStack
      */
     public void addFoodHistory(ServerPlayer player, ItemStack foodStack, int maxHistory) {
-        LinkedList<ItemStack> history = getFoodHistory(player);
-        history.add(foodStack.copy()); // アイテムスタックはコピーして保存
-        if (history.size() > maxHistory) {
-            history.removeFirst();
-        }
-        FOOD_HISTORY.get(player).setFood(history);
+        FoodHistory history = getFoodHistory(player);
+        history.add(foodStack.copy(), maxHistory);
         // オプション：チャットにメッセージを表示
         //player.sendSystemMessage(Component.literal("食事履歴を取得"));
     }
@@ -58,7 +49,7 @@ public class FoodEventHandlerFabric  implements IFoodEventHandler {
      * @param player      クライアント側のプレイヤー
      * @param foodHistory サーバーから送信された食事履歴
      */
-    public void setFoodHistory(Player player, LinkedList<ItemStack> foodHistory) {
+    public void setFoodHistory(Player player, FoodHistory foodHistory) {
         foodHistories.put(player.getUUID(), foodHistory);
         // オプション：チャットにメッセージを表示
         FOOD_HISTORY.get(player).setFood(foodHistory);
@@ -67,7 +58,7 @@ public class FoodEventHandlerFabric  implements IFoodEventHandler {
 
     public void resetFoodHistory(Player player) {
         foodHistories.remove(player.getUUID());
-        FOOD_HISTORY.get(player).setFood(new LinkedList<>());
+        FOOD_HISTORY.get(player).setFood(new FoodHistory());
     }
 
     /**
@@ -79,18 +70,12 @@ public class FoodEventHandlerFabric  implements IFoodEventHandler {
      */
     public int countFoodEaten(Player player, ItemStack target) {
         //LinkedList<ItemStack> history = foodHistories.get(player.getUUID());
-        LinkedList<ItemStack> history = FOOD_HISTORY.get(player).getHistory();
+        if(player == null) return 0;
+        FoodHistory history = FOOD_HISTORY.get(player).getHistory();
         if (history == null) {
             return 0;
         }
-        int count = 0;
-        // 対象のアイテムと同じかどうかを getItem() で判定
-        for (ItemStack stack : history) {
-            if (stack.getItem().equals(target.getItem())) {
-                count++;
-            }
-        }
-        return count;
+        return history.getAmountConsumed(target);
     }
 
     /**
@@ -104,14 +89,15 @@ public class FoodEventHandlerFabric  implements IFoodEventHandler {
      */
     public int countFoodEatenRecent(Player player, ItemStack target, int n) {
         //LinkedList<ItemStack> history = foodHistories.get(player.getUUID());
-        LinkedList<ItemStack> history = FOOD_HISTORY.get(player).getHistory();
-        if (history == null || history.isEmpty()) {
+        if(player == null) return 0;
+        FoodHistory history = FOOD_HISTORY.get(player).getHistory(); // this maintains the default method of checking as the number of
+        if (history == null || history.consumedItems.isEmpty()) {
             return 0;
         }
         int count = 0;
         int processed = 0;
         // 最新の履歴から逆順に n 件分だけ走査
-        for (Iterator<ItemStack> iterator = history.descendingIterator(); iterator.hasNext() && processed < n; processed++) {
+        for (Iterator<ItemStack> iterator = history.consumedItems.descendingIterator(); iterator.hasNext() && processed < n; processed++) {
             ItemStack stack = iterator.next();
             if (stack.getItem().equals(target.getItem())) {
                 count++;
@@ -121,8 +107,8 @@ public class FoodEventHandlerFabric  implements IFoodEventHandler {
     }
 
     @Override
-    public LinkedList<ItemStack> getClientFoodHistory(Player player) {
-        LinkedList<ItemStack> history = FOOD_HISTORY.get(player).getHistory();
-        return history != null ? history : new LinkedList<>();
+    public FoodHistory getClientFoodHistory(Player player) {
+        FoodHistory history = FOOD_HISTORY.get(player).getHistory();
+        return history != null ? history : new FoodHistory();
     }
 }

--- a/forge/src/main/java/com/github/leopoko/solclassic/forge/foodhistory/FoodHistoryManagerForge.java
+++ b/forge/src/main/java/com/github/leopoko/solclassic/forge/foodhistory/FoodHistoryManagerForge.java
@@ -1,24 +1,24 @@
 package com.github.leopoko.solclassic.forge.foodhistory;
 
+import com.github.leopoko.solclassic.utils.FoodHistory;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
-import java.util.LinkedList;
 
 public class FoodHistoryManagerForge {
     private static final String FOOD_HISTORY_TAG = "FoodHistory";
 
     // プレイヤーに食事履歴を保存
-    public static void saveFoodHistory(Player player, LinkedList<ItemStack> foodHistory) {
+    public static void saveFoodHistory(Player player, FoodHistory foodHistory) {
 
         CompoundTag playerData = player.getPersistentData();
         ListTag foodHistoryTag = new ListTag();
 
         // 食べ物履歴をNBTに変換して保存
-        for (ItemStack stack : foodHistory) {
+        for (ItemStack stack : foodHistory.consumedItems) {
             CompoundTag stackTag = new CompoundTag();
             stack.save(stackTag);  // ItemStackをNBTに変換
             foodHistoryTag.add(stackTag);
@@ -29,8 +29,8 @@ public class FoodHistoryManagerForge {
     }
 
     // プレイヤーから食事履歴を読み込む
-    public static LinkedList<ItemStack> loadFoodHistory(Player player) {
-        LinkedList<ItemStack> foodHistory = new LinkedList<>();
+    public static FoodHistory loadFoodHistory(Player player) {
+        FoodHistory foodHistory = new FoodHistory();
         CompoundTag playerData = player.getPersistentData();
 
         // プレイヤーのデータから食事履歴を取得

--- a/forge/src/main/java/com/github/leopoko/solclassic/forge/foodhistory/PlayerDataHandlerForge.java
+++ b/forge/src/main/java/com/github/leopoko/solclassic/forge/foodhistory/PlayerDataHandlerForge.java
@@ -3,6 +3,7 @@ package com.github.leopoko.solclassic.forge.foodhistory;
 import com.github.leopoko.solclassic.network.FoodHistoryHolder;
 import com.github.leopoko.solclassic.network.FoodHistorySync;
 import com.github.leopoko.solclassic.network.SyncFoodHistoryPacket;
+import com.github.leopoko.solclassic.utils.FoodHistory;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -23,7 +24,7 @@ public class PlayerDataHandlerForge {
         Player newPlayer = event.getEntity();
 
         // 食事履歴を引き継ぐ
-        LinkedList<ItemStack> originalHistory = FoodHistoryManagerForge.loadFoodHistory(originalPlayer);
+        FoodHistory originalHistory = FoodHistoryManagerForge.loadFoodHistory(originalPlayer);
         FoodHistoryManagerForge.saveFoodHistory(newPlayer, originalHistory);
     }
 
@@ -31,7 +32,7 @@ public class PlayerDataHandlerForge {
     @SubscribeEvent
     public static void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
         Player player = event.getEntity();
-        LinkedList<ItemStack> foodHistory = FoodHistoryHolder.INSTANCE.getFoodHistory((ServerPlayer) player);
+        FoodHistory foodHistory = FoodHistoryHolder.INSTANCE.getFoodHistory((ServerPlayer) player);
 
         // 食事履歴をNBTに保存
         FoodHistoryManagerForge.saveFoodHistory((ServerPlayer) player, foodHistory);
@@ -43,7 +44,7 @@ public class PlayerDataHandlerForge {
         ServerPlayer player = (ServerPlayer) event.getEntity();
 
         // NBTから食事履歴を読み込む
-        LinkedList<ItemStack> foodHistory = FoodHistoryManagerForge.loadFoodHistory(player);
+        FoodHistory foodHistory = FoodHistoryManagerForge.loadFoodHistory(player);
         FoodHistoryHolder.INSTANCE.setFoodHistory(player, foodHistory);
 
         // サーバーからクライアントにパケットを送信して履歴を同期する
@@ -61,7 +62,7 @@ public class PlayerDataHandlerForge {
             ItemStack eatenItem = event.getItem();
 
             // 食事履歴をサーバー側で更新
-            LinkedList<ItemStack> foodHistory = FoodHistoryHolder.INSTANCE.getFoodHistory(player);
+            FoodHistory foodHistory = FoodHistoryHolder.INSTANCE.getFoodHistory(player);
 
             // クライアントに食事履歴を同期
             FoodHistorySync.syncFoodHistory(player);

--- a/forge/src/main/java/com/github/leopoko/solclassic/forge/network/FoodEventHandlerForge.java
+++ b/forge/src/main/java/com/github/leopoko/solclassic/forge/network/FoodEventHandlerForge.java
@@ -1,11 +1,13 @@
 package com.github.leopoko.solclassic.forge.network;
 
 import com.github.leopoko.solclassic.network.IFoodEventHandler;
+import com.github.leopoko.solclassic.utils.FoodHistory;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.food.FoodProperties;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,7 +15,7 @@ import java.util.*;
 
 public class FoodEventHandlerForge implements IFoodEventHandler {
     // プレイヤーごとの食事履歴を保存するマップ（キーはプレイヤーのUUID）
-    private static final Map<UUID, LinkedList<ItemStack>> foodHistories = new WeakHashMap<>();
+    private static final Map<UUID, FoodHistory> foodHistories = new WeakHashMap<>();
 
     /**
      * サーバー側で、指定されたプレイヤーの食事履歴を取得します。
@@ -21,8 +23,8 @@ public class FoodEventHandlerForge implements IFoodEventHandler {
      * @param player サーバー側のプレイヤー
      * @return 食事履歴の LinkedList (存在しない場合は新規作成)
      */
-    public LinkedList<ItemStack> getFoodHistory(ServerPlayer player) {
-        return foodHistories.computeIfAbsent(player.getUUID(), uuid -> new LinkedList<>());
+    public FoodHistory getFoodHistory(ServerPlayer player) {
+        return foodHistories.computeIfAbsent(player.getUUID(), uuid -> new FoodHistory());
     }
 
     /**
@@ -33,11 +35,8 @@ public class FoodEventHandlerForge implements IFoodEventHandler {
      * @param foodStack 追加する食事アイテムの ItemStack
      */
     public void addFoodHistory(ServerPlayer player, ItemStack foodStack, int maxHistory) {
-        LinkedList<ItemStack> history = getFoodHistory(player);
-        history.add(foodStack.copy()); // アイテムスタックはコピーして保存
-        if (history.size() > maxHistory) {
-            history.removeFirst();
-        }
+        FoodHistory history = getFoodHistory(player);
+        history.add(foodStack.copy(), maxHistory); // アイテムスタックはコピーして保存
         // オプション：チャットにメッセージを表示
         //player.sendSystemMessage(Component.literal("食事履歴が更新されました"));
     }
@@ -49,7 +48,7 @@ public class FoodEventHandlerForge implements IFoodEventHandler {
      * @param player      クライアント側のプレイヤー
      * @param foodHistory サーバーから送信された食事履歴
      */
-    public void setFoodHistory(Player player, LinkedList<ItemStack> foodHistory) {
+    public void setFoodHistory(Player player, FoodHistory foodHistory) {
         foodHistories.put(player.getUUID(), foodHistory);
         // オプション：チャットにメッセージを表示
         //player.sendSystemMessage(Component.literal("食事履歴が更新されました"));
@@ -67,18 +66,11 @@ public class FoodEventHandlerForge implements IFoodEventHandler {
      * @return 食事履歴内に記録されている、対象アイテムの個数
      */
     public int countFoodEaten(Player player, ItemStack target) {
-        LinkedList<ItemStack> history = foodHistories.get(player.getUUID());
+        FoodHistory history = foodHistories.get(player.getUUID());
         if (history == null) {
             return 0;
         }
-        int count = 0;
-        // 対象のアイテムと同じかどうかを getItem() で判定
-        for (ItemStack stack : history) {
-            if (stack.getItem().equals(target.getItem())) {
-                count++;
-            }
-        }
-        return count;
+        return history.getAmountConsumed(target);
     }
 
     /**
@@ -91,7 +83,7 @@ public class FoodEventHandlerForge implements IFoodEventHandler {
      * @return 直近 n 件中に対象アイテムが出現した回数
      */
     public int countFoodEatenRecent(Player player, ItemStack target, int n) {
-        LinkedList<ItemStack> history = foodHistories.get(player.getUUID());
+        LinkedList<ItemStack> history = foodHistories.get(player.getUUID()).consumedItems;
         if (history == null || history.isEmpty()) {
             return 0;
         }
@@ -108,9 +100,9 @@ public class FoodEventHandlerForge implements IFoodEventHandler {
     }
 
     @Override
-    public LinkedList<ItemStack> getClientFoodHistory(Player player) {
-        LinkedList<ItemStack> history = foodHistories.get(player.getUUID());
-        return history != null ? history : new LinkedList<>();
+    public FoodHistory getClientFoodHistory(Player player) {
+        FoodHistory history = foodHistories.get(player.getUUID());
+        return history != null ? history : new FoodHistory();
     }
 
     /**


### PR DESCRIPTION
This is a back end change that optimizes counting the number of repeat times a specific food has been used by putting the count on a separate cache that is updated along with the item list history.